### PR TITLE
fix: favicon parsing

### DIFF
--- a/packages/link-preview/src/index.ts
+++ b/packages/link-preview/src/index.ts
@@ -92,7 +92,7 @@ export async function linkPreview(request: IRequest): Promise<Response> {
 				})
 				.on('link', {
 					element(element) {
-						if (element.getAttribute('rel') === 'icon') {
+						if (element.getAttribute('rel')?.toLowerCase().includes('icon')) {
 							appendUrl(element.getAttribute('href'), res.favicons);
 						}
 					},


### PR DESCRIPTION
![image](https://github.com/toeverything/affine-workers/assets/584378/c02bd03e-58b5-42b3-829b-02a809a2f68a)
rel could be a space delimeted field.