### PR TITLE
fix: deprecated in favor of router.fetch

### DIFF
--- a/packages/worker/src/affine.ts
+++ b/packages/worker/src/affine.ts
@@ -17,6 +17,6 @@ export function AFFiNEWorker(): RouterHandler<Env> {
   router.all('*', () => respMethodNotAllowed());
 
   return (request: Request, env: Env, ctx: ExecutionContext) => {
-    return router.handle(request, env, ctx);
+    return router.fetch(request, env, ctx);
   };
 }


### PR DESCRIPTION
According to [migration guide](https://itty.dev/itty-router/migrations/v4-v5#_1-router-handle-is-deprecated-in-favor-of-router-fetch), itty-router dropped the support for `router.handle`.